### PR TITLE
Implememt timing metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # microcosm-metrics
+
+Opinionated metrics configuration.
+
+Designed to support both vanilla and `DataDog` [statsd](https://github.com/etsy/statsd),
+but focused on `DataDog`.
+
+
+## Usage
+
+ 1. Configure a metrics client:
+
+        # either use vanilla statsd
+        graph.use("statsd")
+
+        # or use the datadog implementation
+        graph.use("datadog_statsd")
+
+ 2. In either case, use the resulting `graph.metrics` client:
+
+        metrics.increment("foo")
+
+ 3. Better still, use the decorators:
+
+        @graph.metrics_timing
+        def my_func():
+            pass
+
+
+## DataDog Testing
+
+First, run the `DataDog Agent` (requires an `API_KEY`). For example, using Docker:
+
+    docker run -d --name datadog-agent -p 8125:8125/udp -e API_KEY=${API_KEY} datadog/docker-dd-agent:latest
+
+Then, use the included CLI to validate connectivity:
+
+    publish-metric --host $(docker-machine ip development)
+
+The resulting metric should appear in `DataDog` "Metric Summary" right away.

--- a/microcosm_metrics/decorators.py
+++ b/microcosm_metrics/decorators.py
@@ -1,0 +1,36 @@
+"""
+Metrics decorators.
+
+"""
+from functools import wraps
+from time import time
+
+from microcosm_metrics.naming import name_for
+
+
+def configure_metrics_timing(graph):
+    """
+    Configure a timing decorator.
+
+    """
+    def metrics_timing(name):
+        """
+        Create a decorator that times a specific context.
+
+        """
+        def decorator(func):
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                start_time = time()
+                try:
+                    return func(*args, **kwargs)
+                finally:
+                    end_time = time()
+                    # NB: the statsd client doesn't actually have this interface
+                    graph.metrics.histogram(
+                        name_for(name),
+                        end_time - start_time,
+                    )
+            return wrapper
+        return decorator
+    return metrics_timing

--- a/microcosm_metrics/factories.py
+++ b/microcosm_metrics/factories.py
@@ -1,0 +1,67 @@
+"""
+Factories for statsd/metrics clients.
+
+"""
+from datadog import DogStatsd
+from microcosm.api import defaults
+from statsd import StatsClient
+
+
+def attach(graph, statsd):
+    """
+    Attach statsd client to `metrics` key for pseudo polymorphism.
+
+    """
+    graph.metrics = statsd
+    return statsd
+
+
+@defaults(
+    host="localhost",
+    port=8125,
+    tags=[],
+)
+def configure_statsd(graph):
+    """
+    Create a vanilla statsd client.
+
+    """
+    if graph.metadata.testing:
+        from mock import MagicMock
+        cls = MagicMock
+    else:
+        cls = StatsClient
+
+    statsd = cls(
+        host=graph.config.datadog_statsd.host,
+        port=graph.config.datadog_statsd.port,
+    )
+
+    return attach(graph, statsd)
+
+
+@defaults(
+    host="localhost",
+    port=8125,
+    tags=[],
+)
+def configure_datadog_statsd(graph):
+    """
+    Create a DataDog statsd client.
+
+    """
+    if graph.metadata.testing:
+        from mock import MagicMock
+        cls = MagicMock
+    else:
+        cls = DogStatsd
+
+    statsd = cls(
+        host=graph.config.datadog_statsd.host,
+        port=graph.config.datadog_statsd.port,
+        constant_tags=[
+            graph.metadata.name,
+        ] + graph.config.datadog_statsd.tags,
+    )
+
+    return attach(graph, statsd)

--- a/microcosm_metrics/main.py
+++ b/microcosm_metrics/main.py
@@ -1,0 +1,48 @@
+"""
+Test CLI for metric integration.
+
+"""
+from argparse import ArgumentParser
+from getpass import getuser
+from time import sleep
+
+from microcosm.api import create_object_graph
+from microcosm.loaders import load_from_dict
+
+from microcosm_metrics.naming import name_for
+
+
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument("--host", default="localhost")
+    return parser.parse_args()
+
+
+def create_statsd_client():
+    args = parse_args()
+    loader = load_from_dict(dict(
+        datadog_statsd=dict(
+            host=args.host,
+        ),
+    ))
+    graph = create_object_graph("metrics", loader=loader)
+    graph.use("datadog_statsd")
+    graph.lock()
+
+    return graph.metrics
+
+
+def publish():
+    """
+    Publish a metric (for testing).
+
+    """
+    statsd = create_statsd_client()
+
+    statsd.increment(name_for(getuser()))
+
+    try:
+        # wait a little to allow the delivery of the metric before we exit
+        sleep(1.0)
+    except KeyboardInterrupt:
+        pass

--- a/microcosm_metrics/naming.py
+++ b/microcosm_metrics/naming.py
@@ -1,0 +1,8 @@
+"""
+Naming conventions.
+
+"""
+
+
+def name_for(key, prefix="microcosm"):
+    return "{}.{}".format(prefix, key)

--- a/microcosm_metrics/tests/test_decorators.py
+++ b/microcosm_metrics/tests/test_decorators.py
@@ -1,0 +1,44 @@
+"""
+Test decorators.
+
+"""
+from time import sleep
+
+from hamcrest import (
+    assert_that,
+    empty,
+    equal_to,
+    greater_than,
+    is_,
+    not_none,
+)
+from microcosm.api import create_object_graph
+
+
+def test_metrics_timing():
+    """
+    Validate that the timing decorator calls a histogram.
+
+    """
+    graph = create_object_graph("example", testing=True)
+    graph.use(
+        "statsd",
+        "metrics_timing",
+    )
+    graph.lock()
+
+    assert_that(graph.metrics_timing, is_(not_none()))
+
+    @graph.metrics_timing("foo")
+    def foo():
+        sleep(1.0)
+
+    foo()
+    graph.metrics.histogram.assert_called()
+
+    _, args, kwargs = graph.metrics.histogram.mock_calls[0]
+    name, value = args
+
+    assert_that(name, is_(equal_to("microcosm.foo")))
+    assert_that(value, is_(greater_than(1.0)))
+    assert_that(kwargs, is_(empty()))

--- a/microcosm_metrics/tests/test_factories.py
+++ b/microcosm_metrics/tests/test_factories.py
@@ -1,0 +1,49 @@
+"""
+Factory tests.
+
+"""
+from hamcrest import (
+    assert_that,
+    contains,
+    equal_to,
+    is_,
+    not_none,
+)
+from microcosm.api import create_object_graph
+
+
+def test_statsd():
+    """
+    Assert that factory returns something.
+
+    Note that during unit tests, the result will be a MagicMock.
+
+    """
+    graph = create_object_graph("example", testing=True)
+    graph.use("statsd")
+    graph.lock()
+
+    assert_that(graph.statsd, is_(not_none()))
+    assert_that(graph.metrics, is_(not_none()))
+
+    assert_that(graph.metrics.host, is_(equal_to("localhost")))
+    assert_that(graph.metrics.port, is_(equal_to(8125)))
+
+
+def test_datadog_statsd():
+    """
+    Assert that factory returns something.
+
+    Note that during unit tests, the result will be a MagicMock.
+
+    """
+    graph = create_object_graph("example", testing=True)
+    graph.use("datadog_statsd")
+    graph.lock()
+
+    assert_that(graph.datadog_statsd, is_(not_none()))
+    assert_that(graph.metrics, is_(not_none()))
+
+    assert_that(graph.metrics.host, is_(equal_to("localhost")))
+    assert_that(graph.metrics.port, is_(equal_to(8125)))
+    assert_that(graph.metrics.constant_tags, contains("example"))

--- a/microcosm_metrics/tests/test_naming.py
+++ b/microcosm_metrics/tests/test_naming.py
@@ -1,0 +1,15 @@
+"""
+Naming tests.
+
+"""
+from hamcrest import (
+    assert_that,
+    equal_to,
+    is_,
+)
+
+from microcosm_metrics.naming import name_for
+
+
+def test_metrics_timing():
+    assert_that(name_for("foo"), is_(equal_to("microcosm.foo")))

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,10 @@ setup(
     zip_safe=False,
     keywords="microcosm",
     install_requires=[
+        "datadog>=0.15.0",
         "microcosm>=0.16.0",
         "microcosm-logging>=0.13.0",
+        "statsd>=3.2.1",
     ],
     setup_requires=[
         "nose>=1.3.6",
@@ -25,7 +27,13 @@ setup(
     dependency_links=[
     ],
     entry_points={
+        "console_scripts": [
+            "publish-metric = microcosm_metrics.main:publish",
+        ],
         "microcosm.factories": [
+            "datadog_statsd = microcosm_metrics.factories:configure_datadog_statsd",
+            "metrics_timing = microcosm_metrics.decorators:configure_metrics_timing",
+            "statsd = microcosm_metrics.factories:configure_statsd",
         ],
     },
     tests_require=[


### PR DESCRIPTION
This PR introduces:
 -  factories for creating both `statsd` and `DataDog` statsd clients
 -  decorators for timing function calls