### PR TITLE
Use microcosm_environment in metrics to distinguish namespaces in Datadog

### DIFF
--- a/microcosm_metrics/decorators.py
+++ b/microcosm_metrics/decorators.py
@@ -27,7 +27,7 @@ def configure_metrics_counting(graph):
                 try:
                     return classifier(*args, **kwargs)
                 finally:
-                    environment = environ.get("MICROCOSM_ENVIRONMENT", "missing")
+                    environment = environ.get("MICROCOSM_ENVIRONMENT", "undefined")
                     if classifier.label is not None:
                         graph.metrics.increment(
                             name_for(
@@ -61,7 +61,7 @@ def configure_metrics_timing(graph):
                     return func(*args, **kwargs)
                 finally:
                     end_time = time()
-                    environment = environ.get("MICROCOSM_ENVIRONMENT", "missing")
+                    environment = environ.get("MICROCOSM_ENVIRONMENT", "undefined")
                     graph.metrics.histogram(
                         name_for(
                             name,

--- a/microcosm_metrics/decorators.py
+++ b/microcosm_metrics/decorators.py
@@ -3,6 +3,7 @@ Metrics decorators.
 
 """
 from functools import wraps
+from os import environ
 from time import time
 
 from microcosm_metrics.classifier import Classifier
@@ -26,6 +27,7 @@ def configure_metrics_counting(graph):
                 try:
                     return classifier(*args, **kwargs)
                 finally:
+                    environment = environ.get("MICROCOSM_ENVIRONMENT", "missing")
                     if classifier.label is not None:
                         graph.metrics.increment(
                             name_for(
@@ -33,6 +35,7 @@ def configure_metrics_counting(graph):
                                 classifier.label,
                                 "count",
                                 prefix=graph.metadata.name,
+                                environment=environment,
                             ),
                         )
             return wrapper
@@ -58,8 +61,13 @@ def configure_metrics_timing(graph):
                     return func(*args, **kwargs)
                 finally:
                     end_time = time()
+                    environment = environ.get("MICROCOSM_ENVIRONMENT", "missing")
                     graph.metrics.histogram(
-                        name_for(name, prefix=graph.metadata.name),
+                        name_for(
+                            name,
+                            prefix=graph.metadata.name,
+                            environment=environment,
+                        ),
                         end_time - start_time,
                     )
             return wrapper

--- a/microcosm_metrics/naming.py
+++ b/microcosm_metrics/naming.py
@@ -16,4 +16,5 @@ def name_for(*keys, **kwargs):
 
     """
     prefix = kwargs.get("prefix", "microcosm")
-    return ".".join([prefix] + list(keys))
+    environment = kwargs.get("environment", "missing")
+    return ".".join([prefix, environment] + list(keys))

--- a/microcosm_metrics/naming.py
+++ b/microcosm_metrics/naming.py
@@ -16,5 +16,5 @@ def name_for(*keys, **kwargs):
 
     """
     prefix = kwargs.get("prefix", "microcosm")
-    environment = kwargs.get("environment", "missing")
+    environment = kwargs.get("environment", "undefined")
     return ".".join([prefix, environment] + list(keys))

--- a/microcosm_metrics/naming.py
+++ b/microcosm_metrics/naming.py
@@ -17,4 +17,4 @@ def name_for(*keys, **kwargs):
     """
     prefix = kwargs.get("prefix", "microcosm")
     environment = kwargs.get("environment", "undefined")
-    return ".".join([prefix, environment] + list(keys))
+    return ".".join([environment, prefix] + list(keys))

--- a/microcosm_metrics/tests/test_decorators.py
+++ b/microcosm_metrics/tests/test_decorators.py
@@ -2,6 +2,7 @@
 Test decorators.
 
 """
+from os import environ
 from time import sleep
 
 from hamcrest import (
@@ -15,58 +16,65 @@ from hamcrest import (
 from microcosm.api import create_object_graph
 
 
-def test_metrics_counting():
-    """
-    Validate that the counting decorator calls increment.
+class TestDecorators(object):
 
-    """
-    graph = create_object_graph("example", testing=True)
-    graph.use(
-        "statsd",
-        "metrics_counting",
-    )
-    graph.lock()
+    def setup(self):
+        environ["MICROCOSM_ENVIRONMENT"] = "testing"
 
-    assert_that(graph.metrics_counting, is_(not_none()))
+    def teardown(self):
+        environ["MICROCOSM_ENVIRONMENT"] = ""
 
-    @graph.metrics_counting("foo")
-    def foo():
-        pass
+    def test_metrics_counting(self):
+        """
+        Validate that the counting decorator calls increment.
 
-    foo()
-    graph.metrics.increment.assert_called()
+        """
+        graph = create_object_graph("example", testing=True)
+        graph.use(
+            "statsd",
+            "metrics_counting",
+        )
+        graph.lock()
 
-    _, args, kwargs = graph.metrics.increment.mock_calls[0]
-    name, = args
+        assert_that(graph.metrics_counting, is_(not_none()))
 
-    assert_that(name, is_(equal_to("example.foo.call.count")))
-    assert_that(kwargs, is_(empty()))
+        @graph.metrics_counting("foo")
+        def foo():
+            pass
 
+        foo()
+        graph.metrics.increment.assert_called()
 
-def test_metrics_timing():
-    """
-    Validate that the timing decorator calls a histogram.
+        _, args, kwargs = graph.metrics.increment.mock_calls[0]
+        name, = args
 
-    """
-    graph = create_object_graph("example", testing=True)
-    graph.use(
-        "statsd",
-        "metrics_timing",
-    )
-    graph.lock()
+        assert_that(name, is_(equal_to("example.testing.foo.call.count")))
+        assert_that(kwargs, is_(empty()))
 
-    assert_that(graph.metrics_timing, is_(not_none()))
+    def test_metrics_timing(self):
+        """
+        Validate that the timing decorator calls a histogram.
 
-    @graph.metrics_timing("foo")
-    def foo():
-        sleep(1.0)
+        """
+        graph = create_object_graph("example", testing=True)
+        graph.use(
+            "statsd",
+            "metrics_timing",
+        )
+        graph.lock()
 
-    foo()
-    graph.metrics.histogram.assert_called()
+        assert_that(graph.metrics_timing, is_(not_none()))
 
-    _, args, kwargs = graph.metrics.histogram.mock_calls[0]
-    name, value = args
+        @graph.metrics_timing("foo")
+        def foo():
+            sleep(1.0)
 
-    assert_that(name, is_(equal_to("example.foo")))
-    assert_that(value, is_(greater_than(1.0)))
-    assert_that(kwargs, is_(empty()))
+        foo()
+        graph.metrics.histogram.assert_called()
+
+        _, args, kwargs = graph.metrics.histogram.mock_calls[0]
+        name, value = args
+
+        assert_that(name, is_(equal_to("example.testing.foo")))
+        assert_that(value, is_(greater_than(1.0)))
+        assert_that(kwargs, is_(empty()))

--- a/microcosm_metrics/tests/test_decorators.py
+++ b/microcosm_metrics/tests/test_decorators.py
@@ -48,7 +48,7 @@ class TestDecorators(object):
         _, args, kwargs = graph.metrics.increment.mock_calls[0]
         name, = args
 
-        assert_that(name, is_(equal_to("example.testing.foo.call.count")))
+        assert_that(name, is_(equal_to("testing.example.foo.call.count")))
         assert_that(kwargs, is_(empty()))
 
     def test_metrics_timing(self):
@@ -75,6 +75,6 @@ class TestDecorators(object):
         _, args, kwargs = graph.metrics.histogram.mock_calls[0]
         name, value = args
 
-        assert_that(name, is_(equal_to("example.testing.foo")))
+        assert_that(name, is_(equal_to("testing.example.foo")))
         assert_that(value, is_(greater_than(1.0)))
         assert_that(kwargs, is_(empty()))

--- a/microcosm_metrics/tests/test_naming.py
+++ b/microcosm_metrics/tests/test_naming.py
@@ -14,7 +14,7 @@ from microcosm_metrics.naming import name_for
 class TestNaming(object):
 
     def test_naming(self):
-        assert_that(name_for("foo", "bar", environment="testing"), is_(equal_to("microcosm.testing.foo.bar")))
+        assert_that(name_for("foo", "bar", environment="testing"), is_(equal_to("testing.microcosm.foo.bar")))
 
     def test_naming_prefix(self):
-        assert_that(name_for("foo", prefix="example", environment="testing"), is_(equal_to("example.testing.foo")))
+        assert_that(name_for("foo", prefix="example", environment="testing"), is_(equal_to("testing.example.foo")))

--- a/microcosm_metrics/tests/test_naming.py
+++ b/microcosm_metrics/tests/test_naming.py
@@ -11,9 +11,10 @@ from hamcrest import (
 from microcosm_metrics.naming import name_for
 
 
-def test_naming():
-    assert_that(name_for("foo", "bar"), is_(equal_to("microcosm.foo.bar")))
+class TestNaming(object):
 
+    def test_naming(self):
+        assert_that(name_for("foo", "bar", environment="testing"), is_(equal_to("microcosm.testing.foo.bar")))
 
-def test_naming_prefix():
-    assert_that(name_for("foo", prefix="example"), is_(equal_to("example.foo")))
+    def test_naming_prefix(self):
+        assert_that(name_for("foo", prefix="example", environment="testing"), is_(equal_to("example.testing.foo")))


### PR DESCRIPTION
* Why? Because metrics are collected without namespaces currently, which makes
all stats for `dev|test|staging` appear as one.