### PR TITLE
Remove python2isms

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.3
+current_version = 1.0.0
 commit = False
 tag = False
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@
 
 machine:
   python:
-      version: 2.7.11
+      version: 3.6.2
 
 general:
   artifacts:
@@ -12,7 +12,7 @@ general:
 dependencies:
   override:
     - pip install tox tox-pyenv
-    - pyenv local 2.7.11 3.5.1  # Should correspond to pre-installed Python versions on CircleCI
+    - pyenv local 3.6.2
 
 test:
   override:

--- a/microcosm_metrics/classifier.py
+++ b/microcosm_metrics/classifier.py
@@ -7,7 +7,7 @@ from functools import wraps
 from microcosm_metrics.naming import CALL, FAILURE, SUCCESS
 
 
-class Classifier(object):
+class Classifier:
     """
     A classifier produces labels based on the outcomes of a wrapped function.
 

--- a/microcosm_metrics/tests/test_decorators.py
+++ b/microcosm_metrics/tests/test_decorators.py
@@ -16,7 +16,7 @@ from hamcrest import (
 from microcosm.api import create_object_graph
 
 
-class TestDecorators(object):
+class TestDecorators:
 
     def setup(self):
         environ["MICROCOSM_ENVIRONMENT"] = "testing"

--- a/microcosm_metrics/tests/test_naming.py
+++ b/microcosm_metrics/tests/test_naming.py
@@ -11,7 +11,7 @@ from hamcrest import (
 from microcosm_metrics.naming import name_for
 
 
-class TestNaming(object):
+class TestNaming:
 
     def test_naming(self):
         assert_that(name_for("foo", "bar", environment="testing"), is_(equal_to("testing.microcosm.foo.bar")))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-metrics"
-version = "0.2.3"
+version = "1.0.0"
 
 setup(
     name=project,
@@ -16,10 +16,10 @@ setup(
     zip_safe=False,
     keywords="microcosm",
     install_requires=[
-        "datadog>=0.15.0",
-        "microcosm>=0.17.2",
-        "microcosm-logging>=0.13.0",
-        "statsd>=3.2.1",
+        "datadog>=0.17.0",
+        "microcosm>=2.0.0",
+        "microcosm-logging>=1.0.0",
+        "statsd>=3.2.2",
     ],
     setup_requires=[
         "nose>=1.3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, lint
+envlist = py36, lint
 
 [testenv]
 commands =
@@ -10,7 +10,7 @@ deps =
 
 [testenv:lint]
 commands=flake8 --max-line-length 120 microcosm_metrics
-basepython=python2.7
+basepython=python3.6
 deps=
     flake8
     flake8-print


### PR DESCRIPTION
 - Build only 3.6
 - Remove six usage
 - Remove legacy class-object inheritance
 - Bump major version