### PR TITLE
Fix GLOB-25359: Use tags instead of mangling names.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 2.0.0
 commit = False
 tag = False
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ Designed to support [DataDog statsd](http://docs.datadoghq.com/guides/dogstatsd/
 
         graph.metrics.increment("foo")
 
+## Tags
+
+A tag for the environment will always be added:
+it will either be the value of the environment variable `MICROCOSM_ENVIRONMENT` or
+`"undefined"` if it is not defined or is empty.
+A tag for the service will always be added,
+which will be the `microcosm` object graph's `name`
+(the first argument to `create_object_graph`).
+
+Further tags can be added by controlling the configuration for
+`datadog_statsd.tags`,
+for example by defining the environment variable
+`<NAME>__DATADOG_STATSD__TAGS` to a JSON-serialized list
+and using `load_from_environ_as_json`.
+In that case, note that none of the tags are allowed to end in a `:`.
 
 ## Decorators
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,17 @@
 
 Opinionated metrics configuration.
 
-Designed primary to support [DataDog statsd](http://docs.datadoghq.com/guides/dogstatsd/), but some
-effort has been made to support [vanilla statsd](https://github.com/etsy/statsd).
-
+Designed to support [DataDog statsd](http://docs.datadoghq.com/guides/dogstatsd/)-compatible servers.
 
 ## Usage
 
  1. Configure a metrics client:
 
-        # either use vanilla statsd
-        graph.use("statsd")
-
-        # or use the datadog implementation
         graph.use("datadog_statsd")
 
- 2. In either case, use the resulting `graph.metrics` client:
+ 2. Use the resulting `graph.metrics` client:
 
-        metrics.increment("foo")
+        graph.metrics.increment("foo")
 
 
 ## Decorators
@@ -57,18 +51,18 @@ Then pass the classifier class to the counting decorator:
 
 ## StatsD Testing
 
-First, run the `statsd`. For example, using Docker:
+First, run the `statsd` server. For example, using Docker:
 
-    docker run -d --name graphite \
-        -p 80:80 -p 2003-2004:2003-2004 -p 2023-2024:2023-2024 -p 8125:8125/udp -p 8126:8126 \
-        hopsoft/graphite-statsd
+    docker run --name statsd -d \
+               -p 0.0.0.0:9102:9102 \
+               -p 0.0.0.0:8125:9125/udp \
+               prom/statsd-exporter
 
 Then, use the included CLIT to validate connectivity:
 
-    publish-metric --statsd statsd --host $(docker-machine ip default)
+    publish-metric --host $(docker-machine ip default)
 
-The resulting metric should appear in the `graphite` dashboard.
-
+The resulting metric should appear in the `/metrics` endpoint.
 
 ## DataDog Testing
 
@@ -78,6 +72,6 @@ First, run the `DataDog Agent` (requires an `API_KEY`). For example, using Docke
 
 Then, use the included CLI to validate connectivity:
 
-    publish-metric --statsd datadog --host $(docker-machine ip default)
+    publish-metric --host $(docker-machine ip default)
 
 The resulting metric should appear in `DataDog` "Metric Summary" right away.

--- a/microcosm_metrics/decorators.py
+++ b/microcosm_metrics/decorators.py
@@ -14,7 +14,7 @@ def configure_metrics_counting(graph):
     Configure a counting decorator.
 
     """
-    def metrics_counting(name, classifier_cls=Classifier):
+    def metrics_counting(name, tags=None, classifier_cls=Classifier):
         """
         Create a decorator that counts a specific context.
 
@@ -33,6 +33,7 @@ def configure_metrics_counting(graph):
                                 classifier.label,
                                 "count",
                             ),
+                            tags=tags,
                         )
             return wrapper
         return decorator
@@ -44,7 +45,7 @@ def configure_metrics_timing(graph):
     Configure a timing decorator.
 
     """
-    def metrics_timing(name):
+    def metrics_timing(name, tags=None):
         """
         Create a decorator that times a specific context.
 
@@ -60,6 +61,7 @@ def configure_metrics_timing(graph):
                     graph.metrics.histogram(
                         name_for(name),
                         end_time - start_time,
+                        tags=tags,
                     )
             return wrapper
         return decorator

--- a/microcosm_metrics/decorators.py
+++ b/microcosm_metrics/decorators.py
@@ -27,15 +27,12 @@ def configure_metrics_counting(graph):
                 try:
                     return classifier(*args, **kwargs)
                 finally:
-                    environment = environ.get("MICROCOSM_ENVIRONMENT", "undefined")
                     if classifier.label is not None:
                         graph.metrics.increment(
                             name_for(
                                 name,
                                 classifier.label,
                                 "count",
-                                prefix=graph.metadata.name,
-                                environment=environment,
                             ),
                         )
             return wrapper
@@ -61,13 +58,8 @@ def configure_metrics_timing(graph):
                     return func(*args, **kwargs)
                 finally:
                     end_time = time()
-                    environment = environ.get("MICROCOSM_ENVIRONMENT", "undefined")
                     graph.metrics.histogram(
-                        name_for(
-                            name,
-                            prefix=graph.metadata.name,
-                            environment=environment,
-                        ),
+                        name_for(name),
                         end_time - start_time,
                     )
             return wrapper

--- a/microcosm_metrics/decorators.py
+++ b/microcosm_metrics/decorators.py
@@ -3,7 +3,6 @@ Metrics decorators.
 
 """
 from functools import wraps
-from os import environ
 from time import time
 
 from microcosm_metrics.classifier import Classifier

--- a/microcosm_metrics/factories.py
+++ b/microcosm_metrics/factories.py
@@ -2,52 +2,10 @@
 Factories for statsd/metrics clients.
 
 """
-from types import MethodType
+from os import environ
 
 from datadog import DogStatsd
 from microcosm.api import defaults
-from statsd import StatsClient
-
-
-def attach(graph, statsd):
-    """
-    Attach statsd client to `metrics` key for pseudo polymorphism.
-
-    """
-    return graph.assign("metrics", statsd)
-
-
-@defaults(
-    host="localhost",
-    port=8125,
-    tags=[],
-)
-def configure_statsd(graph):
-    """
-    Create a vanilla statsd client.
-
-    """
-    if graph.metadata.testing:
-        from mock import MagicMock
-        cls = MagicMock
-    else:
-        cls = StatsClient
-
-    statsd = cls(
-        host=graph.config.datadog_statsd.host,
-        port=graph.config.datadog_statsd.port,
-    )
-
-    if not graph.metadata.testing:
-        # We have different interfaces between the StatsClient and DogStatsd. Try to adapt the
-        # former to the latter for the decorator use cases.
-        def histogram(self, stat, value, rate=1):
-            return self._send_stat(stat, "{}|h".format(value), rate)
-
-        statsd.increment = statsd.incr
-        statsd.histogram = MethodType(histogram, statsd)
-
-    return attach(graph, statsd)
 
 
 @defaults(
@@ -70,8 +28,12 @@ def configure_datadog_statsd(graph):
         host=graph.config.datadog_statsd.host,
         port=graph.config.datadog_statsd.port,
         constant_tags=[
-            graph.metadata.name,
+            "service:" + graph.metadata.name,
+            # An empty string is *not* a valid value: tags cannot end with a colon.
+            # An environment variable can be set to an empty string. We force empty strings
+            # into "undefined".
+            "environment:" + (environ.get("MICROCOSM_ENVIRONMENT", "") or "undefined")
         ] + graph.config.datadog_statsd.tags,
     )
 
-    return attach(graph, statsd)
+    return graph.assign("metrics", statsd)

--- a/microcosm_metrics/main.py
+++ b/microcosm_metrics/main.py
@@ -15,7 +15,6 @@ from microcosm_metrics.naming import name_for
 def parse_args():
     parser = ArgumentParser()
     parser.add_argument("--host", default="localhost")
-    parser.add_argument("--statsd", choices=["datadog", "statsd"], required=True)
     parser.add_argument("--action", choices=["increment", "histogram"], default="increment")
     return parser.parse_args()
 
@@ -27,8 +26,7 @@ def create_statsd_client(args):
         ),
     ))
     graph = create_object_graph("example", loader=loader)
-    factory = dict(datadog="datadog_statsd", statsd="statsd")[args.statsd]
-    graph.use(factory)
+    graph.use("datadog_statsd")
     graph.lock()
 
     return graph.metrics
@@ -43,9 +41,9 @@ def publish():
     statsd = create_statsd_client(args)
 
     if args.action == "increment":
-        statsd.increment(name_for(getuser(), args.action, prefix="example"))
+        statsd.increment(name_for(getuser(), args.action))
     elif args.action == "histogram":
-        statsd.histogram(name_for(getuser(), args.action, prefix="example"), 1.0)
+        statsd.histogram(name_for(getuser(), args.action), 1.0)
 
     try:
         # wait a little to allow the delivery of the metric before we exit

--- a/microcosm_metrics/naming.py
+++ b/microcosm_metrics/naming.py
@@ -10,11 +10,9 @@ IGNORE = "ignore"
 SUCCESS = "success"
 
 
-def name_for(*keys, **kwargs):
+def name_for(*keys):
     """
     Concatenate a metric name.
 
     """
-    prefix = kwargs.get("prefix", "microcosm")
-    environment = kwargs.get("environment", "undefined")
-    return ".".join([environment, prefix] + list(keys))
+    return ".".join(keys)

--- a/microcosm_metrics/tests/test_decorators.py
+++ b/microcosm_metrics/tests/test_decorators.py
@@ -31,7 +31,7 @@ class TestDecorators:
         """
         graph = create_object_graph("example", testing=True)
         graph.use(
-            "statsd",
+            "datadog_statsd",
             "metrics_counting",
         )
         graph.lock()
@@ -48,7 +48,7 @@ class TestDecorators:
         _, args, kwargs = graph.metrics.increment.mock_calls[0]
         name, = args
 
-        assert_that(name, is_(equal_to("testing.example.foo.call.count")))
+        assert_that(name, is_(equal_to("foo.call.count")))
         assert_that(kwargs, is_(empty()))
 
     def test_metrics_timing(self):
@@ -58,7 +58,7 @@ class TestDecorators:
         """
         graph = create_object_graph("example", testing=True)
         graph.use(
-            "statsd",
+            "datadog_statsd",
             "metrics_timing",
         )
         graph.lock()
@@ -75,6 +75,6 @@ class TestDecorators:
         _, args, kwargs = graph.metrics.histogram.mock_calls[0]
         name, value = args
 
-        assert_that(name, is_(equal_to("testing.example.foo")))
+        assert_that(name, is_(equal_to("foo")))
         assert_that(value, is_(greater_than(1.0)))
         assert_that(kwargs, is_(empty()))

--- a/microcosm_metrics/tests/test_decorators.py
+++ b/microcosm_metrics/tests/test_decorators.py
@@ -49,6 +49,7 @@ class TestDecorators:
         name, = args
 
         assert_that(name, is_(equal_to("foo.call.count")))
+        assert_that(kwargs.pop("tags", None), is_(None))
         assert_that(kwargs, is_(empty()))
 
     def test_metrics_timing(self):
@@ -77,4 +78,5 @@ class TestDecorators:
 
         assert_that(name, is_(equal_to("foo")))
         assert_that(value, is_(greater_than(1.0)))
+        assert_that(kwargs.pop("tags", None), is_(None))
         assert_that(kwargs, is_(empty()))

--- a/microcosm_metrics/tests/test_factories.py
+++ b/microcosm_metrics/tests/test_factories.py
@@ -12,24 +12,6 @@ from hamcrest import (
 from microcosm.api import create_object_graph
 
 
-def test_statsd():
-    """
-    Assert that factory returns something.
-
-    Note that during unit tests, the result will be a MagicMock.
-
-    """
-    graph = create_object_graph("example", testing=True)
-    graph.use("statsd")
-    graph.lock()
-
-    assert_that(graph.statsd, is_(not_none()))
-    assert_that(graph.metrics, is_(not_none()))
-
-    assert_that(graph.metrics.host, is_(equal_to("localhost")))
-    assert_that(graph.metrics.port, is_(equal_to(8125)))
-
-
 def test_datadog_statsd():
     """
     Assert that factory returns something.
@@ -46,4 +28,4 @@ def test_datadog_statsd():
 
     assert_that(graph.metrics.host, is_(equal_to("localhost")))
     assert_that(graph.metrics.port, is_(equal_to(8125)))
-    assert_that(graph.metrics.constant_tags, contains("example"))
+    assert_that(graph.metrics.constant_tags, contains("service:example", "environment:undefined"))

--- a/microcosm_metrics/tests/test_naming.py
+++ b/microcosm_metrics/tests/test_naming.py
@@ -14,7 +14,7 @@ from microcosm_metrics.naming import name_for
 class TestNaming:
 
     def test_naming(self):
-        assert_that(name_for("foo", "bar", environment="testing"), is_(equal_to("testing.microcosm.foo.bar")))
+        assert_that(name_for("foo", "bar"), is_(equal_to("foo.bar")))
 
-    def test_naming_prefix(self):
-        assert_that(name_for("foo", prefix="example", environment="testing"), is_(equal_to("testing.example.foo")))
+    def test_naming_simple(self):
+        assert_that(name_for("foo"), is_(equal_to("foo")))

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
         "datadog>=0.17.0",
         "microcosm>=2.0.0",
         "microcosm-logging>=1.0.0",
-        "statsd>=3.2.2",
         "pyopenssl>=0.14",
     ],
     setup_requires=[
@@ -35,7 +34,6 @@ setup(
             "datadog_statsd = microcosm_metrics.factories:configure_datadog_statsd",
             "metrics_counting = microcosm_metrics.decorators:configure_metrics_counting",
             "metrics_timing = microcosm_metrics.decorators:configure_metrics_timing",
-            "statsd = microcosm_metrics.factories:configure_statsd",
         ],
     },
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-metrics"
-version = "1.0.0"
+version = "2.0.0"
 
 setup(
     name=project,


### PR DESCRIPTION
* Removed statsd-classic support. We only support datadog-statsd now.
* Removed "environment" and "prefix" from names_for. Instead we put them in "constant tags".
* Removed dependency on pystatsd.

Note: This is a backwards incompatiible change.