### PR TITLE
GLOB-25917: Initialize statsd client

### DIFF
--- a/microcosm_metrics/decorators.py
+++ b/microcosm_metrics/decorators.py
@@ -14,6 +14,7 @@ def configure_metrics_counting(graph):
     Configure a counting decorator.
 
     """
+    graph.use("datadog_statsd")
     def metrics_counting(name, tags=None, classifier_cls=Classifier):
         """
         Create a decorator that counts a specific context.
@@ -45,6 +46,7 @@ def configure_metrics_timing(graph):
     Configure a timing decorator.
 
     """
+    graph.use("datadog_statsd")
     def metrics_timing(name, tags=None):
         """
         Create a decorator that times a specific context.


### PR DESCRIPTION
Why?

Otherwise, when trying to increment the metric, it would fail on
not having a client configured in the graph. Since we only support
the `datadog_statsd` client library, we make sure it is configured.
This removes the responsibility from initializing the client from the
end application using it.