### PR TITLE
Convert elapsed time metrics to milliseconds

### DIFF
--- a/microcosm_metrics/decorators.py
+++ b/microcosm_metrics/decorators.py
@@ -64,7 +64,7 @@ def configure_metrics_timing(graph):
                     end_time = time()
                     graph.metrics.histogram(
                         name_for(name),
-                        end_time - start_time,
+                        (end_time - start_time) * 1000,
                         tags=tags,
                     )
             return wrapper

--- a/microcosm_metrics/tests/test_decorators.py
+++ b/microcosm_metrics/tests/test_decorators.py
@@ -7,6 +7,7 @@ from time import sleep
 
 from hamcrest import (
     assert_that,
+    close_to,
     empty,
     equal_to,
     greater_than,
@@ -78,6 +79,6 @@ class TestDecorators:
         name, value = args
 
         assert_that(name, is_(equal_to("foo")))
-        assert_that(value, is_(greater_than(1.0)))
+        assert_that(value, is_(close_to(1000, 100)))
         assert_that(kwargs.pop("tags", None), is_(none()))
         assert_that(kwargs, is_(empty()))

--- a/microcosm_metrics/tests/test_decorators.py
+++ b/microcosm_metrics/tests/test_decorators.py
@@ -10,7 +10,6 @@ from hamcrest import (
     close_to,
     empty,
     equal_to,
-    greater_than,
     is_,
     none,
     not_none,


### PR DESCRIPTION
Allows metrics tracking to converge on a single unit.