### PR TITLE
Fix classifier tagging during count metrics

### DIFF
--- a/microcosm_metrics/decorators.py
+++ b/microcosm_metrics/decorators.py
@@ -32,14 +32,13 @@ def configure_metrics_counting(graph):
                     return classifier(*args, **kwargs)
                 finally:
                     if classifier.label is not None:
-                        tags.append(f"classifier:{classifier.label}")
                         graph.metrics.increment(
                             name_for(
                                 name,
                                 "call",
                                 "count",
                             ),
-                            tags=tags,
+                            tags=tags + [f"classifier:{classifier.label}"],
                         )
             return wrapper
         return decorator

--- a/microcosm_metrics/tests/test_decorators.py
+++ b/microcosm_metrics/tests/test_decorators.py
@@ -44,14 +44,17 @@ class TestDecorators:
             pass
 
         foo()
+        foo()
         graph.metrics.increment.assert_called()
+        assert_that(graph.metrics.increment.call_count, is_(2))
 
-        _, args, kwargs = graph.metrics.increment.mock_calls[0]
-        name, = args
+        for call in graph.metrics.increment.mock_calls:
+            _, args, kwargs = call
+            name, = args
 
-        assert_that(name, is_(equal_to("foo.call.count")))
-        assert_that(kwargs.pop("tags", None), is_(equal_to(['classifier:call'])))
-        assert_that(kwargs, is_(empty()))
+            assert_that(name, is_(equal_to("foo.call.count")))
+            assert_that(kwargs.pop("tags", None), is_(equal_to(['classifier:call'])))
+            assert_that(kwargs, is_(empty()))
 
     def test_metrics_timing(self):
         """

--- a/microcosm_metrics/tests/test_decorators.py
+++ b/microcosm_metrics/tests/test_decorators.py
@@ -53,7 +53,38 @@ class TestDecorators:
             name, = args
 
             assert_that(name, is_(equal_to("foo.call.count")))
-            assert_that(kwargs.pop("tags", None), is_(equal_to(['classifier:call'])))
+            assert_that(kwargs.pop("tags", None), is_(equal_to(["classifier:call"])))
+            assert_that(kwargs, is_(empty()))
+
+    def test_metrics_counting_with_tags(self):
+        """
+        Validate that the counting decorator calls increment and respects existing tags.
+
+        """
+        graph = create_object_graph("example", testing=True)
+        graph.use(
+            "metrics",
+            "metrics_counting",
+        )
+        graph.lock()
+
+        assert_that(graph.metrics_counting, is_(not_none()))
+
+        @graph.metrics_counting("foo", tags=["existing:tag"])
+        def foo():
+            pass
+
+        foo()
+        foo()
+        graph.metrics.increment.assert_called()
+        assert_that(graph.metrics.increment.call_count, is_(2))
+
+        for call in graph.metrics.increment.mock_calls:
+            _, args, kwargs = call
+            name, = args
+
+            assert_that(name, is_(equal_to("foo.call.count")))
+            assert_that(kwargs.pop("tags", None), is_(equal_to(["existing:tag", "classifier:call"])))
             assert_that(kwargs, is_(empty()))
 
     def test_metrics_timing(self):


### PR DESCRIPTION
This would previously add the current classifier label to the existing
list of tags on every invocation. We should instead by combining it with
the existing, labeled tags for the endpoint.