### PR TITLE
Supporting metrics name

### DIFF
--- a/microcosm_metrics/factories.py
+++ b/microcosm_metrics/factories.py
@@ -24,12 +24,13 @@ def configure_metrics(graph, configuration="metrics"):
         cls = DogStatsd
 
     config = getattr(graph.config, configuration)
+    metric_service_name = environ.get("METRICS_NAME", graph.metadata.name)
 
     statsd = cls(
         host=config.host,
         port=config.port,
         constant_tags=[
-            "service:" + graph.metadata.name,
+            f"service:{metric_service_name}"
             # An empty string is *not* a valid value: tags cannot end with a colon.
             # An environment variable can be set to an empty string. We force empty strings
             # into "undefined".


### PR DESCRIPTION
Currently, `graph.metadata.name` is the "parent" service name and not
the real daemon name. For example: if the daemon name is
`blanca-events`, `graph.metadata.name` is going to be `blanca`.

This is messing with the stats and does not expose them correctly.